### PR TITLE
Fix version number and table creation if not exists

### DIFF
--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -1609,11 +1609,15 @@ class Driver:
         Returns the neo4j version.
         """
 
-        return self.driver.query(
-            """
-                CALL dbms.components()
-                YIELD name, versions, edition
-                UNWIND versions AS version
-                RETURN version AS version
-            """,
-        )[0][0]['version']
+        try:
+            neo4j_version = self.query(
+                """
+                    CALL dbms.components()
+                    YIELD name, versions, edition
+                    UNWIND versions AS version
+                    RETURN version AS version
+                """,
+            )[0][0]['version']
+            return neo4j_version
+        except Exception as e:
+            logger.warning(f'Error detecting Neo4j version: {e}')

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -833,10 +833,10 @@ class Driver:
 
         with self.fallback():
             resp, summary = self.query(query=query)
-            databases = [record['name'] for record in resp]
 
-        if name in databases:
-            return resp[0].get(field, resp[0])
+        for record in resp:
+            if name == record['name']:
+                return record.get(field, record[0])
 
 
     def db_online(self, name: str | None = None):

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -1009,9 +1009,9 @@ class Driver:
         Requires the database to be empty.
         """
 
-        neo4j_version = self.get_neo4j_version()
+        neo4j_version = self.get_neo4j_major_version()
 
-        if neo4j_version.version >= 5:
+        if neo4j_version >= 5:
             self.drop_constraints()
 
         else:
@@ -1045,13 +1045,13 @@ class Driver:
 
         what_u = self._idx_cstr_synonyms(what)
 
-        neo4j_version = self.get_neo4j_version()
+        neo4j_version = self.get_neo4j_major_version()
 
         with self.session() as s:
 
             try:
 
-                if neo4j_version.version >= 5:
+                if neo4j_version >= 5:
                     indices = s.run(f'SHOW {what}')
                 else:
                     indices = s.run(f'CALL db. {what}')
@@ -1604,9 +1604,9 @@ class Driver:
 
         return self._queries.get('last_failed')
 
-    def get_neo4j_version(self):
+    def get_neo4j_major_version(self) -> int:
         """
-        Returns the neo4j version.
+        Returns the neo4j major version.
         """
 
         try:
@@ -1617,7 +1617,7 @@ class Driver:
                     UNWIND versions AS version
                     RETURN version AS version
                 """,
-            )[0][0]['version']
-            return neo4j_version
+            )[0][0]['version'].split('.')[0]
+            return int(neo4j_version)
         except Exception as e:
             logger.warning(f'Error detecting Neo4j version: {e}')

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -1010,7 +1010,7 @@ class Driver:
         Requires the database to be empty.
         """
 
-        major_neo4j_version = self.neo4j_version.split('.')[0]
+        major_neo4j_version = int(self.neo4j_version.split('.')[0])
 
         if major_neo4j_version >= 5:
             self.drop_constraints()
@@ -1046,7 +1046,7 @@ class Driver:
 
         what_u = self._idx_cstr_synonyms(what)
 
-        major_neo4j_version = self.neo4j_version.split('.')[0]
+        major_neo4j_version = int(self.neo4j_version.split('.')[0])
 
         with self.session() as s:
 

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -566,12 +566,12 @@ class Driver:
             logger.info(f'Offline mode, not running query: `{query}`.')
 
             return None, None
-
-        db = db or self._db_config['db'] or neo4j.DEFAULT_DATABASE
+        if 'CREATE' not in query and 'SHOW DATABASES' not in query:
+            db = db or self._db_config['db'] or neo4j.DEFAULT_DATABASE
         fetch_size = fetch_size or self._db_config['fetch_size']
         raise_errors = (
             self._db_config['raise_errors']
-                if raise_errors is None else
+            if raise_errors is None else
             raise_errors
         )
 
@@ -833,8 +833,7 @@ class Driver:
         query = 'SHOW DATABASES'
 
         with self.fallback():
-
-            resp, summary = self.query(query=query)
+            resp, summary = self.query(query=query, db=neo4j.DEFAULT_DATABASE)
             databases = [record['name'] for record in resp]
 
         if name in databases:
@@ -1345,7 +1344,7 @@ class Driver:
         """
 
         return {
-                r['LABELS(n)'][0]:
+            r['LABELS(n)'][0]:
                 r['COUNT(*)']
             for r in
             self.query(
@@ -1374,7 +1373,7 @@ class Driver:
         """
 
         return {
-                r['TYPE(r)']:
+            r['TYPE(r)']:
                 r['COUNT(*)']
             for r in
             self.query(
@@ -1566,9 +1565,9 @@ class Driver:
 
             return (
                 e.__class__
-                    if isinstance(e, Exception) else
+                if isinstance(e, Exception) else
                 getattr(builtins, e, getattr(neo4j_exc, e, e))
-                    if isinstance(e, str) else
+                if isinstance(e, str) else
                 e
             )
 
@@ -1577,15 +1576,15 @@ class Driver:
         errors = {str_to_exc(e) for e in _misc.to_set(errors)}
 
         return (
-            error in errors or
-            (
-                isinstance(error, type) and
-                any(
-                    issubclass(error, e)
-                    for e in errors
-                    if isinstance(e, type)
+                error in errors or
+                (
+                        isinstance(error, type) and
+                        any(
+                            issubclass(error, e)
+                            for e in errors
+                            if isinstance(e, type)
+                        )
                 )
-            )
         )
 
 

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -570,7 +570,7 @@ class Driver:
         fetch_size = fetch_size or self._db_config['fetch_size']
         raise_errors = (
             self._db_config['raise_errors']
-            if raise_errors is None else
+                if raise_errors is None else
             raise_errors
         )
 
@@ -832,13 +832,11 @@ class Driver:
         query = 'SHOW DATABASES'
 
         with self.fallback():
-            resp, summary = self.query(query=query, db=neo4j.DEFAULT_DATABASE)
+            resp, summary = self.query(query=query)
             databases = [record['name'] for record in resp]
 
         if name in databases:
             return resp[0].get(field, resp[0])
-        else:
-            return None
 
 
     def db_online(self, name: str | None = None):
@@ -1564,7 +1562,7 @@ class Driver:
 
             return (
                 e.__class__
-                if isinstance(e, Exception) else
+                    if isinstance(e, Exception) else
                 getattr(builtins, e, getattr(neo4j_exc, e, e))
                 if isinstance(e, str) else
                 e
@@ -1575,15 +1573,15 @@ class Driver:
         errors = {str_to_exc(e) for e in _misc.to_set(errors)}
 
         return (
-                error in errors or
-                (
-                        isinstance(error, type) and
-                        any(
-                            issubclass(error, e)
-                            for e in errors
-                            if isinstance(e, type)
-                        )
+            error in errors or
+            (
+                isinstance(error, type) and
+                any(
+                    issubclass(error, e)
+                    for e in errors
+                    if isinstance(e, type)
                 )
+            )
         )
 
 

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -836,7 +836,7 @@ class Driver:
 
         for record in resp:
             if name == record['name']:
-                return record.get(field, record[0])
+                return record.get(field, None)
 
 
     def db_online(self, name: str | None = None):

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -78,7 +78,7 @@ class Driver:
             offline: bool = False,
             fallback_db: str | tuple[str] | None = None,
             fallback_on: str | set[str] | None = None,
-            multi_db: bool | None = None, # legacy parameter for pre-4.0 DBs
+            multi_db: bool | None = None,  # legacy parameter for pre-4.0 DBs
             **kwargs
     ):
         """
@@ -834,7 +834,7 @@ class Driver:
 
         with self.fallback():
 
-            resp, summary = self.query(query)
+            resp, summary = self.query(query=query, db=name)
 
         if resp:
 

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -830,18 +830,17 @@ class Driver:
 
         name = name or self.current_db
 
-        query = f'SHOW DATABASES WHERE name = "{name}";'
+        query = 'SHOW DATABASES'
 
         with self.fallback():
 
-            try:
-                resp, summary = self.query(query=query)
-            except neo4j.exceptions.ClientError:
-                return None
+            resp, summary = self.query(query=query)
+            databases = [record['name'] for record in resp]
 
-        if resp:
-
+        if name in databases:
             return resp[0].get(field, resp[0])
+        else:
+            return None
 
 
     def db_online(self, name: str | None = None):

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -834,7 +834,10 @@ class Driver:
 
         with self.fallback():
 
-            resp, summary = self.query(query=query, db=name)
+            try:
+                resp, summary = self.query(query=query)
+            except neo4j.exceptions.ClientError:
+                return None
 
         if resp:
 

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -1610,6 +1610,8 @@ class Driver:
         """
         Returns the neo4j version.
         """
+        if self.version is None:
+            self.get_neo4j_version()
         return self.version
 
     def get_neo4j_version(self):

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -1603,3 +1603,17 @@ class Driver:
         """
 
         return self._queries.get('last_failed')
+
+    def get_neo4j_version(self):
+        """
+        Returns the neo4j version.
+        """
+
+        return self.driver.query(
+            """
+                CALL dbms.components()
+                YIELD name, versions, edition
+                UNWIND versions AS version
+                RETURN version AS version
+            """,
+        )[0][0]['version']

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -39,7 +39,6 @@ import neo4j.exceptions as neo4j_exc
 import neo4j_utils._misc as _misc
 import neo4j_utils._print as printer
 import neo4j_utils._query as _query
-import neo4j_utils._n4jversion as _n4jversion
 
 __all__ = ['CONFIG_FILES', 'DEFAULT_CONFIG', 'Driver']
 
@@ -1010,7 +1009,7 @@ class Driver:
         Requires the database to be empty.
         """
 
-        neo4j_version = _n4jversion.Neo4jVersion()
+        neo4j_version = self.get_neo4j_version()
 
         if neo4j_version.version >= 5:
             self.drop_constraints()
@@ -1046,7 +1045,7 @@ class Driver:
 
         what_u = self._idx_cstr_synonyms(what)
 
-        neo4j_version = _n4jversion.Neo4jVersion()
+        neo4j_version = self.get_neo4j_version()
 
         with self.session() as s:
 

--- a/neo4j_utils/_driver.py
+++ b/neo4j_utils/_driver.py
@@ -62,7 +62,7 @@ class Driver:
     """
 
     _connect_essential = ('uri', 'user', 'passwd')
-    version: str
+    version: str = None
 
     def __init__(
             self,

--- a/neo4j_utils/_n4jversion.py
+++ b/neo4j_utils/_n4jversion.py
@@ -1,4 +1,3 @@
-from typing import Union
 import re
 import subprocess
 
@@ -12,7 +11,7 @@ class Neo4jVersion:
     Provides version information for Neo4j.
     """
 
-    major: Union[int, None]
+    major: int | None
 
     def __init__(self):
         """Get the neo4j version from the neo4j-admin command."""

--- a/neo4j_utils/_n4jversion.py
+++ b/neo4j_utils/_n4jversion.py
@@ -1,3 +1,4 @@
+from typing import Union
 import re
 import subprocess
 
@@ -11,7 +12,7 @@ class Neo4jVersion:
     Provides version information for Neo4j.
     """
 
-    major: int | None
+    major: Union[int, None]
 
     def __init__(self):
         """Get the neo4j version from the neo4j-admin command."""

--- a/neo4j_utils/_query.py
+++ b/neo4j_utils/_query.py
@@ -17,6 +17,8 @@ import collections
 
 __all__ = ['Query']
 
+from typing import Optional
+
 
 class Query(
         collections.namedtuple('QueryBase', ('query', 'args')),
@@ -29,4 +31,4 @@ class Query(
 
 
 Query.__new__.__defaults__ = (None,)
-Query.__annotations__ = {'query': str, 'args': dict | None}
+Query.__annotations__ = {'query': str, 'args': Optional[dict]}


### PR DESCRIPTION
This PR contains two fixes:
- In case the defined table does not exist it should be created. Currently, the executed query to check if the database exists already fails, because the not existing database name is part of the query. This PR fixes this behavior to create the table if it does not exist. 
- Fix to get the version number if `neo4j-admin` is not present (e.g. in a CICD setup with Neo4j in a Docker container).

@deeenes Can you have a look at it?
Thanks in advance!